### PR TITLE
Fix error detection

### DIFF
--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -87,7 +87,7 @@ class Azure extends AbstractProvider
     {
         if (isset($data['error'])) {
             throw new IdentityProviderException(
-                (isset($data['error']['message']) ? $data['error']['message'] : $response->getReasonPhrase()),
+                (isset($data['error_description']) ? $data['error_description'] : $response->getReasonPhrase()),
                 $response->getStatusCode(),
                 (string)$response->getBody()
             );

--- a/tests/src/Provider/AzureTest.php
+++ b/tests/src/Provider/AzureTest.php
@@ -160,7 +160,7 @@ class AzureTest extends TestCase
 
         $postResponse = m::mock('Psr\Http\Message\ResponseInterface');
         $postResponse->shouldReceive('getBody')->andReturn(
-            '{"error": {"code": "request_token_expired", "message": "' . $message . '"}}'
+            '{"error": "request_token_expired", "error_description": "' . $message . '"}'
         );
         $postResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
         $postResponse->shouldReceive('getStatusCode')->andReturn(500);


### PR DESCRIPTION
Currently, the code doesn't contain error messages from the Azure backend for me.

The previous error detection code seems to have been copied from stevenmaguire/oauth2-microsoft, but the response format for errors seem to be different when using Azure. The JSON in the body looks like this for me:
```json
{
    "error": "invalid_client",
    "error_description": "AADSTS50011: The redirect URI … [redacted for privacy]",
    "error_codes": [
        50011
    ],
    "timestamp": "2023-12-11 11:06:35Z",
    "trace_id": "[redacted for privacy]",
    "correlation_id": "[redacted for privacy]",
    "error_uri": "https://login.microsoftonline.com/error?code=50011"
}
```

I changed the code which creates the Exception accordingly, and this works for me. The Exception previously only had a generic "Bad Request" error message, with the change it is the one from Azure.