### PR TITLE
Ability to inject the authorization URL through the constructor

### DIFF
--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -39,11 +39,10 @@ class Azure extends AbstractProvider
      * @param string $urlAuthorize Base url for authorization.
      */
     public function __construct(
-        array  $options = [],
-        array  $collaborators = [],
+        array $options = [],
+        array $collaborators = [],
         string $urlAuthorize = 'https://login.microsoftonline.com'
-    )
-    {
+    ) {
         $this->urlAuthorize = $urlAuthorize;
         parent::__construct($options, $collaborators);
     }

--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -28,10 +28,21 @@ class Azure extends AbstractProvider
      *
      * @var string
      */
-    protected $urlAuthorize = 'https://login.microsoftonline.com';
+    protected $urlAuthorize;
 
     /** @var string */
     protected $urlResourceOwnerDetails = 'https://graph.microsoft.com/v1.0/me';
+
+    /**
+     * @param array $options
+     * @param array $collaborators
+     * @param string $urlAuthorize Base url for authorization.
+     */
+    public function __construct(array $options = [], array $collaborators = [], string $urlAuthorize = 'https://login.microsoftonline.com')
+    {
+        $this->urlAuthorize = $urlAuthorize;
+        parent::__construct($options, $collaborators);
+    }
 
     /**
      * Get authorization url to begin OAuth flow

--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -38,7 +38,11 @@ class Azure extends AbstractProvider
      * @param array $collaborators
      * @param string $urlAuthorize Base url for authorization.
      */
-    public function __construct(array $options = [], array $collaborators = [], string $urlAuthorize = 'https://login.microsoftonline.com')
+    public function __construct(
+        array  $options = [],
+        array  $collaborators = [],
+        string $urlAuthorize = 'https://login.microsoftonline.com'
+    )
     {
         $this->urlAuthorize = $urlAuthorize;
         parent::__construct($options, $collaborators);


### PR DESCRIPTION
I've just added the $urlAuthorize property as a optional constructor parameter.

It fixes this [issue](https://github.com/greew/oauth2-azure-provider/issues/2).