### PR TITLE
Inject the Resource Owner Details URL through the constructor

### DIFF
--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -31,19 +31,22 @@ class Azure extends AbstractProvider
     protected $urlAuthorize;
 
     /** @var string */
-    protected $urlResourceOwnerDetails = 'https://graph.microsoft.com/v1.0/me';
+    protected $urlResourceOwnerDetails;
 
     /**
      * @param array $options
      * @param array $collaborators
      * @param string $urlAuthorize Base url for authorization.
+     * @param string $urlResourceOwnerDetails
      */
     public function __construct(
         array $options = [],
         array $collaborators = [],
-        string $urlAuthorize = 'https://login.microsoftonline.com'
+        string $urlAuthorize = 'https://login.microsoftonline.com',
+        string $urlResourceOwnerDetails  = 'https://graph.microsoft.com/v1.0/me'
     ) {
         $this->urlAuthorize = $urlAuthorize;
+        $this->urlResourceOwnerDetails = $urlResourceOwnerDetails;
         parent::__construct($options, $collaborators);
     }
 


### PR DESCRIPTION
Added ability to inject the Resource Owner Details URL through the constructor, which is required to use the library with Microsoft 365 GCC High:

https://learn.microsoft.com/en-us/microsoft-365/enterprise/microsoft-365-u-s-government-gcc-high-endpoints?view=o365-worldwide