### PR TITLE
Change the license on composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "greew/oauth2-azure-provider",
   "description": "An OAuth2 client provider for Microsoft Azure to be used with thephpleague/oauth2-client",
   "type": "library",
-  "license": "GPL-3.0-or-later",
+  "license": "MIT",
   "require": {
     "php": "^7.3 || ^8.0",
     "league/oauth2-client": "^2.6",


### PR DESCRIPTION
The license on composer.json (GPL 3.0) was not compatible with the license defined in the LICENSE file (MIT).

It messes up with composer.lock, which indicates GPL for this library.

I just changed composer.json.

This PR addresses this [issue](https://github.com/greew/oauth2-azure-provider/issues/13).